### PR TITLE
Update fusioncharts.component.ts

### DIFF
--- a/src/angular-fusioncharts/src/fusioncharts.component.ts
+++ b/src/angular-fusioncharts/src/fusioncharts.component.ts
@@ -482,7 +482,9 @@ class FusionChartsComponent
   }
 
   ngOnDestroy() {
-    this.chartObj.dispose();
+    if (this.chartObj) {
+      this.chartObj.dispose();
+    }
   }
 }
 export { FusionChartsComponent };


### PR DESCRIPTION
dispose of undefined happens in a dashboard situation where dashboard is still loading but user changes route. ngOndestroy is triggered and sometimes there is no chartObj