### PR TITLE
Correct the README and stop the published copy from drifting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# angular-fusioncharts
+# Angular FusionCharts
 
 A simple and lightweight official Angular component for the FusionCharts JavaScript charting library. `angular-fusioncharts` lets you add JavaScript charts to your Angular application without any hassle.
 
 > **angular-fusioncharts v5** ships as a modern Angular library (Angular Package Format, partial-Ivy / FESM2022) and supports **Angular 20, 21, and 22** from a single package. It works with **FusionCharts v3 and v4** (validated against FusionCharts **4.2.2**).
 
-- Documentation: [https://www.fusioncharts.com/dev/getting-started/angular/your-first-chart-using-angular](https://www.fusioncharts.com/dev/getting-started/angular/your-first-chart-using-angular)
+- Documentation: [https://www.fusioncharts.com/dev/getting-started/angular/angular/your-first-chart-using-angular](https://www.fusioncharts.com/dev/getting-started/angular/angular/your-first-chart-using-angular)
 - Support: [https://www.fusioncharts.com/contact-support](https://www.fusioncharts.com/contact-support)
 - Github Repo: [https://github.com/fusioncharts/angular-fusioncharts](https://github.com/fusioncharts/angular-fusioncharts)
 - FusionCharts Official Website: [https://www.fusioncharts.com/](https://www.fusioncharts.com/)
@@ -28,6 +28,7 @@ A simple and lightweight official Angular component for the FusionCharts JavaScr
 - [Consuming outside the Angular CLI](#consuming-outside-the-angular-cli)
 - [Migrating to v5](#migrating-to-v5)
 - [For Contributors](#for-contributors)
+  - [Trying a local build of the library inside an example](#trying-a-local-build-of-the-library-inside-an-example)
 - [Going Beyond Charts](#going-beyond-charts)
 - [Licensing](#licensing)
 
@@ -55,7 +56,7 @@ Applications on Angular ≤ 19 should remain on `angular-fusioncharts@4.x`.
 Install the wrapper and FusionCharts together:
 
 ```bash
-npm install angular-fusioncharts fusioncharts --save
+npm install angular-fusioncharts fusioncharts
 ```
 
 `@angular/core` and `fusioncharts` are declared as peer dependencies:
@@ -274,7 +275,7 @@ What changed:
 
 - **Angular floor raised to 20.** Apps on Angular ≤ 19 stay on `angular-fusioncharts@4.x`. Peer range is now `@angular/core ^20 || ^21 || ^22`.
 - **`fusioncharts` is now a peer dependency.** Install it alongside the wrapper (`npm install fusioncharts`). Most projects already did this.
-- **The legacy UMD bundle (`dist/dist/index.js`) is removed.** The package is ESM-only (FESM2022). Standard `npm install` + `import` consumers are unaffected. Only consumers that loaded the UMD file directly (by file path, via `<script>`, or SystemJS) are impacted, switch to the npm package import.
+- **The legacy UMD bundle (`angular-fusioncharts/dist/index.js`) is removed.** The package is ESM-only (FESM2022). Standard `npm install` + `import` consumers are unaffected. Only consumers that loaded the UMD file directly (by file path, via `<script>`, or SystemJS) are impacted, switch to the npm package import.
 
 ## For Contributors
 

--- a/projects/angular-fusioncharts/README.md
+++ b/projects/angular-fusioncharts/README.md
@@ -1,10 +1,10 @@
-# angular-fusioncharts
+# Angular FusionCharts
 
 A simple and lightweight official Angular component for the FusionCharts JavaScript charting library. `angular-fusioncharts` lets you add JavaScript charts to your Angular application without any hassle.
 
 > **angular-fusioncharts v5** ships as a modern Angular library (Angular Package Format, partial-Ivy / FESM2022) and supports **Angular 20, 21, and 22** from a single package. It works with **FusionCharts v3 and v4** (validated against FusionCharts **4.2.2**).
 
-- Documentation: [https://www.fusioncharts.com/dev/getting-started/angular/your-first-chart-using-angular](https://www.fusioncharts.com/dev/getting-started/angular/your-first-chart-using-angular)
+- Documentation: [https://www.fusioncharts.com/dev/getting-started/angular/angular/your-first-chart-using-angular](https://www.fusioncharts.com/dev/getting-started/angular/angular/your-first-chart-using-angular)
 - Support: [https://www.fusioncharts.com/contact-support](https://www.fusioncharts.com/contact-support)
 - Github Repo: [https://github.com/fusioncharts/angular-fusioncharts](https://github.com/fusioncharts/angular-fusioncharts)
 - FusionCharts Official Website: [https://www.fusioncharts.com/](https://www.fusioncharts.com/)
@@ -23,10 +23,12 @@ A simple and lightweight official Angular component for the FusionCharts JavaScr
   - [NgModule application](#ngmodule-application)
 - [Working with Events](#working-with-events)
 - [Working with APIs](#working-with-apis)
+- [Exporting charts](#exporting-charts)
 - [Usage and integration of FusionTime](#usage-and-integration-of-fusiontime)
 - [Consuming outside the Angular CLI](#consuming-outside-the-angular-cli)
 - [Migrating to v5](#migrating-to-v5)
 - [For Contributors](#for-contributors)
+  - [Trying a local build of the library inside an example](#trying-a-local-build-of-the-library-inside-an-example)
 - [Going Beyond Charts](#going-beyond-charts)
 - [Licensing](#licensing)
 
@@ -35,7 +37,7 @@ A simple and lightweight official Angular component for the FusionCharts JavaScr
 | angular-fusioncharts | Angular | FusionCharts |
 |----------------------|---------|--------------|
 | **5.x** | **20, 21, 22** | **3.x / 4.x** (validated on 4.2.2) |
-| 4.x | 17–19 | up to 3.23.0 / 4.x |
+| 4.x | 17-19 | up to 3.23.0 / 4.x |
 
 Applications on Angular ≤ 19 should remain on `angular-fusioncharts@4.x`.
 
@@ -47,14 +49,14 @@ Applications on Angular ≤ 19 should remain on `angular-fusioncharts@4.x`.
   - Angular 20 / 21: Node `^20.19 || ^22.12 || ^24`
   - Angular 22: Node `^22.22.3 || ^24.15.0 || ^26`
 - An **Angular 20, 21, or 22** application.
-- **FusionCharts** installed in your project — it is a **peer dependency** and is provided by you at runtime (it is not bundled).
+- **FusionCharts** installed in your project, it is a **peer dependency** and is provided by you at runtime (it is not bundled).
 
 ### Installation
 
 Install the wrapper and FusionCharts together:
 
 ```bash
-npm install angular-fusioncharts fusioncharts --save
+npm install angular-fusioncharts fusioncharts
 ```
 
 `@angular/core` and `fusioncharts` are declared as peer dependencies:
@@ -68,7 +70,7 @@ npm install angular-fusioncharts fusioncharts --save
 
 ## Quick Start
 
-The component API is unchanged from v4 — `<fusioncharts>` with the same inputs/outputs. The only difference in v5 is packaging.
+The component API is unchanged from v4, `<fusioncharts>` with the same inputs/outputs. The only difference in v5 is packaging.
 
 ### Standalone application (Angular 17+ default)
 
@@ -203,6 +205,33 @@ changeCaption() {
 }
 ```
 
+## Exporting charts
+
+Set `exportEnabled: "1"` in the chart configuration. That is the only thing required: export support already ships inside the main `fusioncharts` package, and no extra module import or `fcRoot` change is needed.
+
+```typescript
+dataSource = {
+  chart: {
+    caption: 'Countries With Most Oil Reserves',
+    theme: 'fusion',
+    exportEnabled: '1',
+  },
+  data: [ /* ... */ ],
+};
+```
+
+An export menu button then appears in the top-right corner of the chart. To export from your own control, call the API on the captured chart instance:
+
+```typescript
+exportChart() {
+  this.chart.exportChart({ exportFormat: 'png' });   // png, jpg, svg, pdf
+}
+```
+
+Export runs client-side by default (`exportMode` defaults to `auto`), producing the file in the browser with no export server involved.
+
+> If `exportEnabled` is not set, `exportChart()` does nothing and reports no error. FusionCharts gates the whole export feature behind that attribute.
+
 ## Usage and integration of FusionTime
 
 You can visualize timeseries data with FusionTime:
@@ -223,7 +252,7 @@ Then build a `DataStore`/`DataTable` and pass it as the chart's `data`. Useful l
 
 ## Consuming outside the Angular CLI
 
-v5 is published in **partial-Ivy** form (Angular Package Format). **Angular CLI consumers need no extra configuration** — the CLI runs the Angular Linker automatically when it builds your app.
+v5 is published in **partial-Ivy** form (Angular Package Format). **Angular CLI consumers need no extra configuration**: the CLI runs the Angular Linker automatically when it builds your app.
 
 If you build your app **without the Angular CLI** (a custom webpack/Rollup/esbuild pipeline with no Angular Linker step), you must run the Angular Linker as a Babel plugin so the partial-Ivy code is fully compiled against your Angular version:
 
@@ -236,21 +265,28 @@ module.exports = {
 };
 ```
 
-Use `@angular/compiler-cli/linker/babel` via `babel-loader` for `node_modules`. This is a one-time setup and supports build caching. Reference: Angular — *Consuming partial-Ivy code outside the Angular CLI*.
+Use `@angular/compiler-cli/linker/babel` via `babel-loader` for `node_modules`. This is a one-time setup and supports build caching. Reference: Angular, *Consuming partial-Ivy code outside the Angular CLI*.
 
 ## Migrating to v5
 
-v5 is a packaging-level major. **Your application code does not change** — same `<fusioncharts>` component, same inputs/outputs, same `fcRoot`/`forRoot`.
+v5 is a packaging-level major. **Your application code does not change**: same `<fusioncharts>` component, same inputs/outputs, same `fcRoot`/`forRoot`.
 
 What changed:
 
 - **Angular floor raised to 20.** Apps on Angular ≤ 19 stay on `angular-fusioncharts@4.x`. Peer range is now `@angular/core ^20 || ^21 || ^22`.
 - **`fusioncharts` is now a peer dependency.** Install it alongside the wrapper (`npm install fusioncharts`). Most projects already did this.
-- **The legacy UMD bundle (`dist/dist/index.js`) is removed.** The package is ESM-only (FESM2022). Standard `npm install` + `import` consumers are unaffected. Only consumers that loaded the UMD file directly (by file path, via `<script>`, or SystemJS) are impacted — switch to the npm package import.
+- **The legacy UMD bundle (`angular-fusioncharts/dist/index.js`) is removed.** The package is ESM-only (FESM2022). Standard `npm install` + `import` consumers are unaffected. Only consumers that loaded the UMD file directly (by file path, via `<script>`, or SystemJS) are impacted, switch to the npm package import.
 
 ## For Contributors
 
-This repository is an Angular library workspace. The library lives in `projects/angular-fusioncharts/`; consumer validation apps live under `examples/` (`ng-app-20-using-fusioncharts-v4`, `ng-app-21-using-fusioncharts-v4`, `ng-app-22-using-fusioncharts-v4`).
+This repository is an Angular library workspace. The library lives in `projects/angular-fusioncharts/`. Consumer validation apps live under `examples/`:
+
+| example | Angular | FusionCharts |
+|---|---|---|
+| `ng-app-20-using-fusioncharts-v4` | 20 | 4.x |
+| `ng-app-21-using-fusioncharts-v4` | 21 | 4.x |
+| `ng-app-22-using-fusioncharts-v4` | 22 | 4.x |
+| `ng-app-20-using-fusioncharts-v3` | 20 | 3.23.0 (evidences the `^3` peer) |
 
 ```bash
 git clone https://github.com/fusioncharts/angular-fusioncharts.git
@@ -260,19 +296,29 @@ npm run build      # builds the library to dist/angular-fusioncharts (ng-packagr
 npm test           # runs the unit tests (vitest)
 ```
 
-To validate against a specific Angular major, pack the build and install the tarball into the matching example app:
+Each example installs `angular-fusioncharts` **from the npm registry**, so it is self-contained. Any example can be copied out of this repository and it will still install and run:
 
 ```bash
-npm run pack                          # creates dist/angular-fusioncharts/angular-fusioncharts-<v>.tgz
-cd examples/ng-app-22-using-fusioncharts-v4 && npm install && npm run build
+cd examples/ng-app-22-using-fusioncharts-v4
+npm install        # or npm ci
+npm run build
+npm start
 ```
 
-> **Important — pack first.** The example apps install the library from the packed tarball
-> (`file:../../dist/angular-fusioncharts/angular-fusioncharts-5.0.0.tgz`), which only exists after you
-> run **`npm run pack` at the repo root**. Always run `npm run pack` before `npm install` inside any
-> `examples/ng-app-*`, otherwise the install will fail because the tarball is missing.
->
-> The v22 example requires **Node ≥ 22.22.3** (or ≥ 24.15.0); apps 20 and 21 run on Node 20.19+/22.12+/24.
+> The v22 example requires **Node 22.22.3+** (or 24.15.0+). Apps 20 and 21 run on Node 20.19+/22.12+/24.
+> Each example pins the TypeScript its Angular major requires: 20 uses `~5.8`, 21 uses `~5.9`, 22 uses `~6.0`.
+
+### Trying a local build of the library inside an example
+
+```bash
+npm run pack       # writes dist/_artifact/angular-fusioncharts-<version>.tgz
+cd examples/ng-app-22-using-fusioncharts-v4
+npm install ../../dist/_artifact/angular-fusioncharts-<version>.tgz
+```
+
+Restore the registry version afterwards by reverting that example's `package.json` and running `npm install`.
+
+> `npm run pack` writes outside `dist/angular-fusioncharts/` on purpose. Packing into the directory you publish from would make the next `npm publish` include the tarball inside itself.
 
 ## Going Beyond Charts
 

--- a/scripts/verify-package.mjs
+++ b/scripts/verify-package.mjs
@@ -168,6 +168,24 @@ try {
   else if (/Google/i.test(license)) fail("LICENSE.md still carries the Angular scaffold placeholder");
   else done("LICENSE.md names FusionCharts");
 
+  // The npm page renders projects/angular-fusioncharts/README.md, not the root
+  // one. The two drifted once: the root copy was corrected in 1c7db989 and the
+  // library copy was not, so 5.0.0-rc.0 shipped instructions telling consumers
+  // to run `npm run pack` before installing an example, which had stopped being
+  // true. Nothing caught it, because no build step reads prose. Keeping the two
+  // byte-identical is the cheapest guarantee that what renders on npm is what
+  // was reviewed on GitHub.
+  const shippedReadme = readFileSync(join(pkgDir, "README.md"), "utf8");
+  const rootReadme = readFileSync(join(repoRoot, "README.md"), "utf8");
+  if (shippedReadme !== rootReadme) {
+    fail(
+      "README.md in the tarball differs from the repository root README.md. " +
+        "The npm page comes from projects/angular-fusioncharts/README.md; update both together.",
+    );
+  } else {
+    done("README.md in the tarball matches the root README.md");
+  }
+
   // @angular/core must stay an external import. If ng-packagr ever inlines it
   // the consumer ends up with two copies of Angular.
   const fesm = readFileSync(join(pkgDir, "fesm2022/angular-fusioncharts.mjs"), "utf8");


### PR DESCRIPTION
## Why

`projects/angular-fusioncharts/README.md` is what renders on the npm package page, and it had drifted from the root README. `1c7db989` corrected the root copy on 05-Aug and left the library copy at its 02-Jul state, so **`5.0.0-rc.0` shipped instructions that are not true**. Confirmed by unpacking the published tarball: its README hashes identical to the pre-fix library copy.

What the npm page currently tells a consumer:

- **Run `npm run pack` before installing any example**, or the install "will fail because the tarball is missing", because the examples install from `file:../../dist/angular-fusioncharts/angular-fusioncharts-5.0.0.tgz`. All four examples install `angular-fusioncharts` from the registry as of `0574955c`.
- **`npm run pack` writes to `dist/angular-fusioncharts/`.** It writes to `dist/_artifact/`, and it was moved there precisely because packing into the publish directory made the next publish ship a package containing itself, which is the regression `verify-package.mjs` already guards.

It was also missing the **Exporting charts** section, which documents the `exportEnabled: "1"` requirement, and the examples table including the FusionCharts v3 app that evidences the `^3` peer range.

## What changed

Corrections applied to the root README, then synced to the library copy, which is now byte-identical:

| | |
|---|---|
| Title | `angular-fusioncharts` to **Angular FusionCharts** |
| Documentation link | was a **404**. The real path repeats the `angular` segment |
| UMD bundle path | `dist/dist/index.js` to `angular-fusioncharts/dist/index.js`, the specifier a 4.2.0 consumer actually imported. Verified against the published 4.2.0 tarball |
| Install command | dropped `--save`, a no-op since npm 5 |
| Table of contents | added the one missing sub-heading |

## The guard

The second commit makes `verify:package` fail when the two READMEs differ.

The typo was not the problem here. The problem is structural: the README that ships is a second copy, and no build step reads prose, so fixing one and not the other is silent. Negative-tested both ways, it fails with the drift reintroduced and passes once synced.

## Verification

- `npm run build`, `npm run verify:package` 11/11, `npm test` 14/14 on node 22.23.2
- Each commit checked out and verified independently, so neither is red
- Every external link in the README re-checked; 14/14 now return 200
- All 16 TOC anchors resolve

## Not included

The README's install command resolves to `4.2.0` today, since `latest` is still `4.2.0` during the RC window. That self-resolves at GA, so it is deliberately not papered over with a note that would need removing again.
